### PR TITLE
Update Dodge Hornet generations: add Wikipedia reference and finalize model year range

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Dodge Hornet
 
+This repository contains signal set configurations for the Dodge Hornet, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Dodge Hornet.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,5 +1,8 @@
+references:
+  - "https://en.wikipedia.org/wiki/Dodge_Hornet"
+
 generations:
   - name: "First Generation"
     start_year: 2023
-    end_year: null
+    end_year: 2025
     description: "The Dodge Hornet is a compact crossover SUV that represents Dodge's return to the segment after more than a decade. Based on the Alfa Romeo Tonale and built alongside it in Italy, the Hornet features distinctive Dodge styling elements including a hood with integrated heat extractors, a mail-slot grille, and Rhombi logo-inspired LED taillights. Two powertrain options are available: the GT model with a 2.0L turbocharged four-cylinder engine producing 268 HP, and the R/T which features a plug-in hybrid system combining a 1.3L turbocharged engine with an electric motor for a total system output of 288 HP and 383 lb-ft of torque. The R/T offers approximately 30 miles of all-electric range and features PowerShot, a performance function that provides a 25 HP boost for up to 15 seconds. The interior maintains most of the Tonale's design but with Dodge-specific elements, including a 12.3-inch digital instrument cluster, a 10.25-inch touchscreen infotainment system with Uconnect 5, and available performance seats. A Track Pack option adds Alcantara trim, aluminum pedals, red-painted Brembo brakes, and unique 20-inch wheels. The Hornet represents Dodge's effort to bring its performance-oriented brand identity to the popular compact SUV segment while leveraging Stellantis's global platforms and electrification strategy."


### PR DESCRIPTION
- Added references array with Dodge Hornet Wikipedia article URL
- Updated end_year from null to 2025 (model years 2023-2025 per Wikipedia)
- Updated README.md with standard template documentation
- Confirmed single First Generation entry (2023-2025) based on Wikipedia infobox and narrative

Wikipedia evidence: Infobox shows "production = August 2022 – present" and "model_years = 2023–2025".
2025 models section describes only "minor changes" (redesigned LED headlights, color options) confirming no facelift/new generation.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
